### PR TITLE
fix META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,7 +4,8 @@
     "description" : "Returns what the character width should be on the terminal.",
     "author" : "Tae Lim Kook",
     "provides" : {
-        "Terminal::WCWidth" : "lib/Terminal/WCWidth.pm6"
+        "Terminal::WCWidth"         : "lib/Terminal/WCWidth.pm6",
+        "Terminal::WCWidth::Tables" : "lib/Terminal/WCWidth/Tables.pm6"
     },
     "depends" : [ ],
     "source-url" : "git://github.com/bluebear94/Terminal-WCWidth.git"


### PR DESCRIPTION
added this line:

``` json
"Terminal::WCWidth::Tables" : "lib/Terminal/WCWidth/Tables.pm6"
```

(editor removed DOS ^M line endings)
