### PR TITLE
Support vs-16

### DIFF
--- a/lib/Terminal/WCWidth.rakumod
+++ b/lib/Terminal/WCWidth.rakumod
@@ -37,10 +37,17 @@ my sub wcwidth(Int:D $ucs) is export {
 
 my sub wcswidth($str) is export {
     my $res = 0;
+    my $prev-w = 0;
     for $str.NFC {
+        if $_ == 0xFE0F && $prev-w == 1 {
+            $res += 1;
+            $prev-w = 0;
+            next;
+        }
         my $w = wcwidth($_);
         return -1 if $w < 0;
         $res += $w;
+        $prev-w = $w;
     }
     $res
 }

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -50,7 +50,7 @@ assert-length("\x1B13\x1B28\x1B2E\x1B44",
 # VS16 (U+FE0F) turns text characters into emoji presentation (width 2)
 assert-length("\x2747\xFE0F",
   (1, 0),
- re j 2,
+  2,
   "❇️ (U+2747 + VS16): is of length 2"
 );
 

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,7 +1,7 @@
 use Test;
 use Terminal::WCWidth;
 
-plan 12;
+plan 16;
 
 sub assert-length(
   $str, @each, $phrase, $msg = "wcwidth test"
@@ -45,6 +45,19 @@ assert-length("\x1B13\x1B28\x1B2E\x1B44",
   (1, 1, 1, 1),
   4,
   "Balinese kapal (ship) is ᬓᬨᬮ᭄ of length 4."
+);
+
+# VS16 (U+FE0F) turns text characters into emoji presentation (width 2)
+assert-length("\x2747\xFE0F",
+  (1, 0),
+ re j 2,
+  "❇️ (U+2747 + VS16): is of length 2"
+);
+
+assert-length("\x2603\xFE0F",
+  (1, 0),
+  2,
+  "☃️ (U+2603 + VS16): is of length 2"
 );
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This change adds support for the vs-16 -- "variation selector" which turns single width characters into double width ones.

The python version has a specific list of characters this applies to -- https://github.com/jquast/wcwidth/blob/master/wcwidth/table_vs16.py -- but I am hoping it is sufficient to apply it to any 1-width character
